### PR TITLE
Add option to supply custom matchers

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,6 +3,7 @@
     "extends": [
         "eslint-config-moxy/es8",
         "eslint-config-moxy/addons/node",
-        "eslint-config-moxy/addons/jest"
+        "eslint-config-moxy/addons/jest",
+        "eslint-config-moxy/addons/object-spread"
     ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,44 +16,138 @@
       }
     },
     "@commitlint/cli": {
-      "version": "5.2.6",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-5.2.6.tgz",
-      "integrity": "sha512-ZifN3JYXXtpopDWk/AGtLJt4FYymAaGKWyxcgk+Z+oHVukQl9HO7IMb3pE/N7gSiQ3nqgCsQTqG83+ABoKfMSw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-6.0.2.tgz",
+      "integrity": "sha512-zFbw1GHSA3SmcGVDRc0nbm//U7jg9kzG5lGhg/bkYf7CcMpiWgTTcRjPSZea8tLl5Yh/A00RcTl+wBFdniOmPw==",
       "dev": true,
       "requires": {
-        "@commitlint/core": "5.2.6",
+        "@commitlint/core": "6.0.2",
         "babel-polyfill": "6.26.0",
         "chalk": "2.3.0",
         "get-stdin": "5.0.1",
-        "lodash": "4.17.4",
+        "lodash.merge": "4.6.0",
+        "lodash.pick": "4.4.0",
         "meow": "3.7.0"
+      },
+      "dependencies": {
+        "@commitlint/core": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/@commitlint/core/-/core-6.0.2.tgz",
+          "integrity": "sha512-dNp0mC4gIxL3zh6s7Yx86tQX0bZ/wNbuclsYYkIpT0J3OXraXEUrGj2Z5nUaTwRa0cfVVSV9gndjY2Ej4KRtKg==",
+          "dev": true,
+          "requires": {
+            "@commitlint/execute-rule": "6.0.2",
+            "@commitlint/is-ignored": "6.0.2",
+            "@commitlint/parse": "6.0.2",
+            "@commitlint/resolve-extends": "6.0.2",
+            "@commitlint/rules": "6.0.2",
+            "@commitlint/top-level": "6.0.2",
+            "@marionebl/sander": "0.6.1",
+            "babel-runtime": "6.26.0",
+            "chalk": "2.3.0",
+            "cosmiconfig": "3.1.0",
+            "git-raw-commits": "1.3.0",
+            "lodash.merge": "4.6.0",
+            "lodash.mergewith": "4.6.0",
+            "lodash.pick": "4.4.0",
+            "lodash.topairs": "4.3.0",
+            "resolve-from": "4.0.0"
+          }
+        }
       }
     },
     "@commitlint/config-conventional": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-5.2.3.tgz",
-      "integrity": "sha512-W2OarrGyHP+ihgqNv6iLSAXBNw5KBXAkuAf2cHD9+KpIA8rTtOCfbZsIc6DNPQc4+0Ysh0jsk6ePrL0NGTtp0w==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-6.0.2.tgz",
+      "integrity": "sha512-RYNxI5cNfH8HIlXVR9tstYLTm0xOnSRee8E3zQmiOEK4xedWzP1/Dl7rtOn5WCrnnRwgc+8aF+sdZ5R92WPt6Q==",
       "dev": true
     },
-    "@commitlint/core": {
-      "version": "5.2.6",
-      "resolved": "https://registry.npmjs.org/@commitlint/core/-/core-5.2.6.tgz",
-      "integrity": "sha512-r6nCZ1QGy3ZWuUTdAjxwjctVplOnAqwHVvL3rR5Oai5nMwqcA+FrJCFX2s7rLwZpQf95lM9+CDA04/YM8zNnVQ==",
+    "@commitlint/ensure": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-6.0.2.tgz",
+      "integrity": "sha512-3ihfq4cIClObMToFKempOkEZhRw6m65IATvRjFCQHuVz7wBbtiXJzCkOdJ2cImgU2Q/1BlIZjqLLR6NRpFuuJQ==",
       "dev": true,
       "requires": {
-        "@marionebl/sander": "0.6.1",
-        "babel-runtime": "6.26.0",
-        "chalk": "2.3.0",
+        "lodash.camelcase": "4.3.0",
+        "lodash.kebabcase": "4.1.1",
+        "lodash.snakecase": "4.1.1",
+        "lodash.startcase": "4.4.0",
+        "lodash.upperfirst": "4.3.1"
+      }
+    },
+    "@commitlint/execute-rule": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-6.0.2.tgz",
+      "integrity": "sha512-D6CEjMPp0GyO8FgP0e16Y3gFt7450kn70tOzsaT6YKgM+81l+JKYdJ4iLHVt2P4hpU1DF+fbOius8xy/WXzWqA==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "@commitlint/is-ignored": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-6.0.2.tgz",
+      "integrity": "sha512-/zo5C+NYWmuWiNiXr4HC5/7P9aAtwdswUdNvQTrGEBBR8+OwtZtlAVHzpuMd3Xj5BXS9XkwT1Yv1rrfdYelppg==",
+      "dev": true,
+      "requires": {
+        "semver": "5.4.1"
+      }
+    },
+    "@commitlint/message": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-6.0.2.tgz",
+      "integrity": "sha512-dMcpQYhfqM8iieIV8sgRUZKFXfklI4tbqstioV7fJ80V4kSv3bhFnIPGC2OlA7msoeuEDb2DGYaOFswsPhvWGg==",
+      "dev": true
+    },
+    "@commitlint/parse": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-6.0.2.tgz",
+      "integrity": "sha512-c+Zm0LjCrDO116BXS3WBrTgtbgLFcTwiYeF7mKFmzcMs+kdvKfUzw08skl42g/4lU9lZWyesNUWd2vNAmXtiSg==",
+      "dev": true,
+      "requires": {
         "conventional-changelog-angular": "1.5.2",
-        "conventional-commits-parser": "2.1.0",
-        "cosmiconfig": "3.1.0",
-        "find-up": "2.1.0",
-        "git-raw-commits": "1.3.0",
-        "lodash": "4.17.4",
+        "conventional-commits-parser": "2.1.0"
+      }
+    },
+    "@commitlint/resolve-extends": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-6.0.2.tgz",
+      "integrity": "sha512-yv4qSF3iAftyOuYMWNES+x6XDL4nZVprWjxM97JzBz8d9jGZvpjq2d/g1NIvVwCmI9q7K9dZTxI2KJw1spXDYQ==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "lodash.merge": "4.6.0",
+        "lodash.omit": "4.5.0",
         "require-uncached": "1.0.3",
         "resolve-from": "4.0.0",
-        "resolve-global": "0.1.0",
-        "semver": "5.4.1"
+        "resolve-global": "0.1.0"
+      }
+    },
+    "@commitlint/rules": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-6.0.2.tgz",
+      "integrity": "sha512-lvlKf9WDdRed1uSz87PoxI26yyGdXxPyYniUnEfm3K7grWdnNVFbz8nkuI3iX6V9K6XVZBzbohans+jvQbKlYw==",
+      "dev": true,
+      "requires": {
+        "@commitlint/ensure": "6.0.2",
+        "@commitlint/message": "6.0.2",
+        "@commitlint/to-lines": "6.0.2",
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "@commitlint/to-lines": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-6.0.2.tgz",
+      "integrity": "sha512-yT8MruPM8HVBhFk6aNnc4g333+riCojsAhzIwc7Dnd1srXQaFcE8NW+20jzD+Gvgafy/OZS5OTuidrt0lNP9eQ==",
+      "dev": true
+    },
+    "@commitlint/top-level": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-6.0.2.tgz",
+      "integrity": "sha512-aou9SdSrU+cl/XtrOj/fFKv6sf7Tc6z+r/N4ajOG4sxri3zzDkunF9AkNkSKEmioFLhFcpDIbip8+IS/fa9Nmw==",
+      "dev": true,
+      "requires": {
+        "find-up": "2.1.0"
       }
     },
     "@marionebl/sander": {
@@ -159,7 +253,7 @@
     "ansi-escapes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
+      "integrity": "sha1-7D6LTp+AZPwCw6ybZfHCdb2o75I=",
       "dev": true
     },
     "ansi-regex": {
@@ -186,7 +280,7 @@
     "anymatch": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+      "integrity": "sha1-VT3Lj5HjyImEXf26NMd3IbkLnXo=",
       "dev": true,
       "requires": {
         "micromatch": "2.3.11",
@@ -240,7 +334,7 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
       "dev": true
     },
     "array-equal": {
@@ -592,7 +686,7 @@
     "babylon": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+      "integrity": "sha1-ry87iPpvXB5MY00aD46sT1WzleM=",
       "dev": true
     },
     "balanced-match": {
@@ -752,7 +846,7 @@
     "circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
       "dev": true
     },
     "cli-cursor": {
@@ -1223,7 +1317,7 @@
         "boom": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "integrity": "sha1-XdnabuOl8wIHdDYpDLcX0/SlTgI=",
           "dev": true,
           "requires": {
             "hoek": "4.2.0"
@@ -1276,7 +1370,7 @@
     "date-fns": {
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
-      "integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw==",
+      "integrity": "sha1-EuYJzcuTUScxHQTTMzTilgoqVOY=",
       "dev": true
     },
     "dateformat": {
@@ -1382,7 +1476,7 @@
     "diff": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
-      "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
+      "integrity": "sha1-sdhVB9rzlkgo3lSzfQ1zumfdpWw=",
       "dev": true
     },
     "doctrine": {
@@ -1447,7 +1541,7 @@
     "es-abstract": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.9.0.tgz",
-      "integrity": "sha512-kk3IJoKo7A3pWJc0OV8yZ/VEX2oSUytfekrJiqoxBlKJMFAJVJVpGdHClCCTdv+Fn2zHfpDHHIelMFhZVfef3Q==",
+      "integrity": "sha1-aQgpoHyuNrIi5/2bdcDQVz6yUic=",
       "dev": true,
       "requires": {
         "es-to-primitive": "1.1.1",
@@ -1477,7 +1571,7 @@
     "escodegen": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.0.tgz",
-      "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
+      "integrity": "sha1-mBGi8mXcHNOJRCDuNxcGS2MriFI=",
       "dev": true,
       "requires": {
         "esprima": "3.1.3",
@@ -1628,7 +1722,7 @@
     "esprima": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+      "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ=",
       "dev": true
     },
     "esquery": {
@@ -1665,7 +1759,7 @@
     "exec-sh": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.1.tgz",
-      "integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
+      "integrity": "sha1-FjuYpuiea2W0fCoo0hW8H2OYnDg=",
       "dev": true,
       "requires": {
         "merge": "1.2.0"
@@ -2841,7 +2935,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
       "dev": true
     },
     "functional-red-black-tree": {
@@ -2859,7 +2953,7 @@
     "get-own-enumerable-property-symbols": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz",
-      "integrity": "sha512-TtY/sbOemiMKPRUDDanGCSgBYe7Mf0vbRsWnBZ+9yghpZ1MvcpSpuZFjHdEeY/LZjZy0vdLjS77L6HosisFiug==",
+      "integrity": "sha1-XErYfyg0xLm06EVJ3B4GUPs4wks=",
       "dev": true
     },
     "get-pkg-repo": {
@@ -2941,7 +3035,7 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
       "dev": true,
       "requires": {
         "fs.realpath": "1.0.0",
@@ -2983,7 +3077,7 @@
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo=",
       "dev": true
     },
     "globby": {
@@ -3084,7 +3178,7 @@
     "hawk": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+      "integrity": "sha1-r02RTrBl+bXOTZ0RwcshJu7MMDg=",
       "dev": true,
       "requires": {
         "boom": "4.3.1",
@@ -3096,7 +3190,7 @@
     "hoek": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ==",
+      "integrity": "sha1-ctnQdU9/4lyi0BrY+PmpRJqJUm0=",
       "dev": true
     },
     "home-or-tmp": {
@@ -3112,7 +3206,7 @@
     "hosted-git-info": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+      "integrity": "sha1-bWDjSzq7yDEwYsO3mO+NkBoHrzw=",
       "dev": true
     },
     "html-encoding-sniffer": {
@@ -3138,7 +3232,7 @@
     "husky": {
       "version": "0.14.3",
       "resolved": "https://registry.npmjs.org/husky/-/husky-0.14.3.tgz",
-      "integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
+      "integrity": "sha1-xp7XTi0neXaaF7qDmbVM4LY8EsM=",
       "dev": true,
       "requires": {
         "is-ci": "1.0.10",
@@ -3157,7 +3251,7 @@
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+      "integrity": "sha1-90aPYBNfXl2tM5nAqBvpoWA6CCs=",
       "dev": true
     },
     "ignore": {
@@ -3206,7 +3300,7 @@
     "inquirer": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+      "integrity": "sha1-ndLyrXZdyrH/BEO0kUQqILoifck=",
       "dev": true,
       "requires": {
         "ansi-escapes": "3.0.0",
@@ -3544,7 +3638,7 @@
     "istanbul-lib-coverage": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
-      "integrity": "sha512-0+1vDkmzxqJIn5rcoEqapSB4DmPxE31EtI2dF2aCkV5esN9EWHxZ0dwgDClivMXJqE7zaYQxq30hj5L0nlTN5Q==",
+      "integrity": "sha1-c7+5mIhSmUFck9OKPprfeEp3qdo=",
       "dev": true
     },
     "istanbul-lib-hook": {
@@ -3997,7 +4091,7 @@
     "js-yaml": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+      "integrity": "sha1-LnhEFka9RoLpY/IrbpKCPDCcYtw=",
       "dev": true,
       "requires": {
         "argparse": "1.0.9",
@@ -4536,10 +4630,58 @@
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
       "dev": true
     },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+      "dev": true
+    },
+    "lodash.kebabcase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
+      "integrity": "sha1-hImxyw0p/4gZXM7KRI/21swpXDY=",
+      "dev": true
+    },
+    "lodash.merge": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
+      "integrity": "sha1-aYhLoUSsM/5plzemCG3v+t0PicU=",
+      "dev": true
+    },
+    "lodash.mergewith": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz",
+      "integrity": "sha1-FQzwoWeR9ZA7iJHqsVRgknS96lU=",
+      "dev": true
+    },
+    "lodash.omit": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
+      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA=",
+      "dev": true
+    },
+    "lodash.pick": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
+      "dev": true
+    },
+    "lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha1-OdcUo1NXFHg3rv1ktdy7Fr7Nj40=",
+      "dev": true
+    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+      "dev": true
+    },
+    "lodash.startcase": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
+      "integrity": "sha1-lDbjTtJgk+1/+uGTYUQ1CRXZrdg=",
       "dev": true
     },
     "lodash.template": {
@@ -4561,10 +4703,22 @@
         "lodash._reinterpolate": "3.0.0"
       }
     },
+    "lodash.topairs": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.topairs/-/lodash.topairs-4.3.0.tgz",
+      "integrity": "sha1-O23qo31g+xFnE8RsXxfqGQ7EjWQ=",
+      "dev": true
+    },
+    "lodash.upperfirst": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz",
+      "integrity": "sha1-E2Xt9DFIBIHvDRxolXpe2Z1J984=",
+      "dev": true
+    },
     "log-symbols": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.1.0.tgz",
-      "integrity": "sha512-zLeLrzMA1A2vRF1e/0Mo+LNINzi6jzBylHj5WqvQ/WK/5WCZt8si9SyN4p9llr/HRYvVR1AoXHRHl4WTHyQAzQ==",
+      "integrity": "sha1-81+mDieIMrU43E3dy7R4pF0+O+Y=",
       "dev": true,
       "requires": {
         "chalk": "2.3.0"
@@ -4641,7 +4795,7 @@
     "lru-cache": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+      "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
       "dev": true,
       "requires": {
         "pseudomap": "1.0.2",
@@ -4761,7 +4915,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "dev": true,
       "requires": {
         "brace-expansion": "1.1.8"
@@ -4824,7 +4978,7 @@
     "node-fetch": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "integrity": "sha1-mA9vcthSEaU0fGsrwYxbhMPrR+8=",
       "dev": true,
       "requires": {
         "encoding": "0.1.12",
@@ -4852,7 +5006,7 @@
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
       "dev": true,
       "requires": {
         "hosted-git-info": "2.5.0",
@@ -4911,7 +5065,7 @@
     "nwmatcher": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.3.tgz",
-      "integrity": "sha512-IKdSTiDWCarf2JTS5e9e2+5tPZGdkRJ79XjYV0pzK8Q9BpsFyBq1RGKxzs7Q8UBushGw7m6TzVKz6fcY99iSWw==",
+      "integrity": "sha1-ZDSOOz2A8DW0CsEVY9J4+LctuJw=",
       "dev": true
     },
     "oauth-sign": {
@@ -5081,7 +5235,7 @@
     "os-locale": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-      "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+      "integrity": "sha1-QrwpAKa1uL0XN2yOiCtlr8zyS/I=",
       "dev": true,
       "requires": {
         "execa": "0.7.0",
@@ -5119,7 +5273,7 @@
     "p-map": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
-      "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+      "integrity": "sha1-5OlPMR6rvIYzoeeZCBZfyiYkG2s=",
       "dev": true
     },
     "parse-github-repo-url": {
@@ -5229,7 +5383,7 @@
     "pluralize": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+      "integrity": "sha1-KYuJ34uTsCIdv0Ia0rGx6iP8Z3c=",
       "dev": true
     },
     "pn": {
@@ -5289,7 +5443,7 @@
     "promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
       "dev": true,
       "requires": {
         "asap": "2.0.6"
@@ -5327,13 +5481,13 @@
     "qs": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+      "integrity": "sha1-NJzfbu+J7EXBLX1es/wMhwNDptg=",
       "dev": true
     },
     "randomatic": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+      "integrity": "sha1-x6vpzIuHwLqodrGf3oP9RkeX44w=",
       "dev": true,
       "requires": {
         "is-number": "3.0.0",
@@ -5416,7 +5570,7 @@
     "readable-stream": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
       "dev": true,
       "requires": {
         "core-util-is": "1.0.2",
@@ -5450,7 +5604,7 @@
     "redux": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
-      "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+      "integrity": "sha1-BrcxIyFZAdJdBlvjQusCa8HIU3s=",
       "dev": true,
       "requires": {
         "lodash": "4.17.4",
@@ -5488,7 +5642,7 @@
     "regex-cache": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+      "integrity": "sha1-db3FiioUls7EihKDW8VMjVYjNt0=",
       "dev": true,
       "requires": {
         "is-equal-shallow": "0.1.3"
@@ -5524,7 +5678,7 @@
     "request": {
       "version": "2.83.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+      "integrity": "sha1-ygtl2gLtYpNYh4COb1EDgQNOM1Y=",
       "dev": true,
       "requires": {
         "aws-sign2": "0.7.0",
@@ -5651,7 +5805,7 @@
     "rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
       "dev": true,
       "requires": {
         "glob": "7.1.2"
@@ -5701,7 +5855,7 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM=",
       "dev": true
     },
     "sane": {
@@ -5723,13 +5877,13 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk=",
       "dev": true
     },
     "semver": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+      "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4=",
       "dev": true
     },
     "set-blocking": {
@@ -5762,7 +5916,7 @@
     "shellwords": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
-      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+      "integrity": "sha1-1rkYHBpI05cyTISHHvvPxz/AZUs=",
       "dev": true
     },
     "signal-exit": {
@@ -5780,7 +5934,7 @@
     "slice-ansi": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+      "integrity": "sha1-BE8aSdiEL/MHqta1Be0Xi9lQE00=",
       "dev": true,
       "requires": {
         "is-fullwidth-code-point": "2.0.0"
@@ -5842,7 +5996,7 @@
     "split": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "integrity": "sha1-YFvZvjA6pZ+zX5Ip++oN3snqB9k=",
       "dev": true,
       "requires": {
         "through": "2.3.8"
@@ -5851,7 +6005,7 @@
     "split2": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
-      "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
+      "integrity": "sha1-GGsldbz4PoW30YRldWI47k7kJJM=",
       "dev": true,
       "requires": {
         "through2": "2.0.3"
@@ -6096,7 +6250,7 @@
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
       "dev": true,
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
@@ -6123,7 +6277,7 @@
     "string_decoder": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
       "dev": true,
       "requires": {
         "safe-buffer": "5.1.1"
@@ -6132,7 +6286,7 @@
     "stringify-object": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.2.1.tgz",
-      "integrity": "sha512-jPcQYw/52HUPP8uOE4kkjxl5bB9LfHkKCTptIk3qw7ozP5XMIMlHMLjt00GGSwW6DJAf/njY5EU6Vpwl4LlBKQ==",
+      "integrity": "sha1-JyDC7/lAhUyBn27iUqrrWB8wYk0=",
       "dev": true,
       "requires": {
         "get-own-enumerable-property-symbols": "2.0.1",
@@ -6217,7 +6371,7 @@
     "table": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
-      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+      "integrity": "sha1-ozRHN1OR52atNNNIbm4q7chNLjY=",
       "dev": true,
       "requires": {
         "ajv": "5.4.0",
@@ -6231,7 +6385,7 @@
     "test-exclude": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
-      "integrity": "sha512-35+Asrsk3XHJDBgf/VRFexPgh3UyETv8IAn/LRTiZjVy6rjPVqdEk8dJcJYBzl1w0XCJM48lvTy8SfEsCWS4nA==",
+      "integrity": "sha1-TYSWSwlmsAh+zDNKLOAC09k0HiY=",
       "dev": true,
       "requires": {
         "arrify": "1.0.1",
@@ -6244,7 +6398,7 @@
     "text-extensions": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.7.0.tgz",
-      "integrity": "sha512-AKXZeDq230UaSzaO5s3qQUZOaC7iKbzq0jOFL614R7d9R593HLqAOL0cYoqLdkNrjBSOdmoQI06yigq1TSBXAg==",
+      "integrity": "sha1-+qq6JiXtdG1WiiPk0KrNm/CKizk=",
       "dev": true
     },
     "text-table": {
@@ -6278,7 +6432,7 @@
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
       "dev": true,
       "requires": {
         "os-tmpdir": "1.0.2"
@@ -6380,7 +6534,7 @@
     "ua-parser-js": {
       "version": "0.7.17",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
-      "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g==",
+      "integrity": "sha1-6exflJi57JEOeuOsYmqAXE0J7Kw=",
       "dev": true
     },
     "uglify-js": {
@@ -6443,7 +6597,7 @@
     "uuid": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+      "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ=",
       "dev": true
     },
     "validate-npm-package-license": {
@@ -6500,7 +6654,7 @@
     "webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "integrity": "sha1-qFWYCx8LazWbodXZ+zmulB+qY60=",
       "dev": true
     },
     "whatwg-encoding": {
@@ -6532,7 +6686,7 @@
     "which": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
       "dev": true,
       "requires": {
         "isexe": "2.0.0"

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -5,22 +5,22 @@ const configureStore = require('redux-mock-store').default;
 const thunkMiddleware = require('redux-thunk').default;
 const assertError = require('./util/assertError');
 
-const initialState = {};
+const { containing } = waitForActions.matchers;
 const action1 = { type: 'ACTION-1', payload: { id: 1, name: 'ACTION ONE' } };
 const action2 = { type: 'ACTION-2', payload: { id: 2, name: 'ACTION TWO' } };
 const action3 = { type: 'ACTION-3', payload: { id: 3, name: 'ACTION THREE' } };
 const action4 = { type: 'ACTION-4', payload: { id: 4, name: 'ACTION FOUR' } };
 const timeoutError = { code: 'ETIMEDOUT', name: 'TimeoutError' };
 const cancelledError = { code: 'ECANCELLED', name: 'CancelledError' };
+const mismatchError = { code: 'EMISMATCH', name: 'MismatchError' };
 const asyncActionsCreator = (actions, timeout = 10) => (dispatch) => {
     const timeoutId = setTimeout(() => {
         clearTimeout(timeoutId);
         actions.forEach((action) => dispatch(action));
     }, timeout);
 };
-const actionsCreator = (actions) => (dispatch) =>
-    actions.forEach((action) => dispatch(action));
-const createMockStore = (middlewares = []) => configureStore(middlewares)(initialState);
+const actionsCreator = (actions) => (dispatch) => actions.forEach((action) => dispatch(action));
+const createMockStore = (middlewares = []) => configureStore(middlewares)();
 
 afterEach(() => {
     jest.useRealTimers();
@@ -36,31 +36,56 @@ it('should resolve the promise when a single action is dispatched', async () => 
     expect(mockStore.getActions()).toEqual([action1]);
 });
 
-it('should resolve the promise when action creator is dispatched', async () => {
+it('should fulfill the promise when action creator is dispatched', async () => {
     const mockStore = createMockStore([thunkMiddleware]);
     const actions = [action1, action2, action3];
 
     mockStore.dispatch(actionsCreator(actions));
-    await waitForActions(mockStore, actions);
+
+    await waitForActions(mockStore, [action1, action2, action3]);
 
     expect(mockStore.getActions()).toEqual(actions);
 });
 
-it('should resolve the promise when async action creator is dispatched', async () => {
+it('should fulfill the promise when async action creator is dispatched', async () => {
     const mockStore = createMockStore([thunkMiddleware]);
     const actions = [action1, action2, action3];
 
     mockStore.dispatch(asyncActionsCreator(actions));
+
     await waitForActions(mockStore, actions);
 
     expect(mockStore.getActions()).toEqual(actions);
 });
 
-it('should resolve the promise when expected actions match a subset of property values of dispatched actions', async () => {
+it('should reject the promise when an action creator is dispatched and the order of expected and dispatched actions mismatch', () => {
+    const mockStore = createMockStore([thunkMiddleware]);
+    const actions = [action1, action2, action3];
+
+    mockStore.dispatch(actionsCreator(actions));
+
+    const promise = waitForActions(mockStore, [action3, action2, action1]);
+
+    return assertError(promise, mismatchError);
+});
+
+it('should reject the promise when an async action creator is dispatched and the order of expected and dispatched actions mismatch', () => {
+    const mockStore = createMockStore([thunkMiddleware]);
+    const actions = [action1, action2, action3];
+
+    mockStore.dispatch(asyncActionsCreator(actions));
+
+    const promise = waitForActions(mockStore, [action3, action1, action2]);
+
+    return assertError(promise, mismatchError);
+});
+
+it('should fulfill the promise when expected actions match a subset of property values of dispatched actions', async () => {
     const mockStore = createMockStore([thunkMiddleware]);
     const actions = [action1, action2, action3, action4];
 
     mockStore.dispatch(actionsCreator(actions));
+
     await waitForActions(mockStore, [
         { type: 'ACTION-1', payload: { id: 1 } },
         { type: 'ACTION-2', payload: { name: 'ACTION TWO' } },
@@ -75,16 +100,17 @@ it('should reject the promise via timeout when expected actions do not match a s
         const actions = [action1, action2];
 
         mockStore.dispatch(actionsCreator(actions));
+
         const promise = waitForActions(mockStore, [
             { type: 'ACTION-1', payload: { a: 1 } },
             { type: 'ACTION-3', payload: { name: 'ACTION THREE' } },
-        ]);
+        ], { matcher: containing });
 
         return assertError(promise, timeoutError);
     }
 );
 
-it('should resolve the promise when no actions are expected', async () => {
+it('should fulfill the promise when no actions are expected', async () => {
     const mockStore = createMockStore();
     const actions = [];
 
@@ -103,7 +129,7 @@ it('should reject the promise when expected actions are not received and timeout
     return assertError(waitForActions(mockStore, actions), timeoutError);
 });
 
-it('should resolve the promise when a single action type is expected', () => {
+it('should fulfill the promise when a single action type is expected', () => {
     const mockStore = createMockStore([thunkMiddleware]);
 
     mockStore.dispatch(action1);
@@ -119,31 +145,45 @@ it('should fulfill the promise when action types are expected', () => {
     return waitForActions(mockStore, ['ACTION-1', 'ACTION-2', 'ACTION-3']);
 });
 
-it('should fulfill the promise when predicate is passed and evaluates to true', async () => {
+it('should fulfill the promise when custom matcher is passed and evaluates to true', async () => {
     const mockStore = createMockStore([thunkMiddleware]);
-    const predicate = jest.fn(() => true);
+    const matcher = jest.fn(() => true);
 
     mockStore.dispatch(action1);
     mockStore.dispatch(action2);
-    await waitForActions(mockStore, predicate);
 
-    expect(predicate).toHaveBeenCalledWith([action1, action2]);
+    await waitForActions(mockStore, [], { matcher });
+
+    expect(matcher).toHaveBeenCalledWith([], [action1, action2]);
 });
 
-it('should reject the promise via timeout when predicate is passed and always evaluates to false', async () => {
+it('should reject the promise via timeout when custom matcher is passed and evaluates to false', async () => {
     const mockStore = createMockStore([thunkMiddleware]);
-    const predicate = jest.fn(() => false);
+    const matcher = jest.fn(() => false);
 
     mockStore.dispatch(action1);
 
-    await assertError(waitForActions(mockStore, predicate), timeoutError);
-    expect(predicate).toHaveBeenCalledWith([action1]);
+    await assertError(waitForActions(mockStore, [], { matcher }), timeoutError);
+
+    expect(matcher).toHaveBeenCalledWith([], [action1]);
+});
+
+it('should reject the promise when custom matcher throws mismatch error', async () => {
+    const mockStore = createMockStore([thunkMiddleware]);
+    const matcher = jest.fn(() => { throw new waitForActions.MismatchError(); });
+
+    mockStore.dispatch(action1);
+
+    await assertError(waitForActions(mockStore, [], { matcher }), mismatchError);
+
+    expect(matcher).toHaveBeenCalledWith([], [action1]);
 });
 
 it('should reject the promise when the default timeout expires', () => {
     jest.useFakeTimers();
 
     const mockStore = createMockStore();
+
     const promise = waitForActions(mockStore, action1);
 
     jest.runAllTimers();
@@ -153,6 +193,7 @@ it('should reject the promise when the default timeout expires', () => {
 
 it('should return a promise with a cancel function', () => {
     const mockStore = createMockStore();
+
     const promise = waitForActions(mockStore, action1);
 
     expect(promise).toHaveProperty('cancel');
@@ -163,7 +204,7 @@ it('should return a promise with a cancel function', () => {
     return promise;
 });
 
-it('should reject the promise if cancel() is called before dispatch of remaining actions', () => {
+it('should reject the promise when cancel() is called before dispatch of remaining actions', () => {
     const mockStore = createMockStore();
 
     const promise = waitForActions(mockStore, [action1, action2, action3]);
@@ -173,13 +214,25 @@ it('should reject the promise if cancel() is called before dispatch of remaining
     return assertError(promise, cancelledError);
 });
 
-it('should reject the promise if the specified timeout expires', () => {
+it('should reject the promise when the specified timeout expires', () => {
     jest.useFakeTimers();
 
     const mockStore = createMockStore();
-    const promise = waitForActions(mockStore, action1, 1000);
+
+    const promise = waitForActions(mockStore, action1, { timeout: 1000 });
 
     jest.runTimersToTime(1000);
 
     return assertError(promise, timeoutError);
+});
+
+it('should fulfill the promise the array of expected actions is contained in the array of dispatched actions', () => {
+    const mockStore = createMockStore([thunkMiddleware]);
+    const actions = [action1, action2, action3];
+
+    mockStore.dispatch(actionsCreator(actions));
+
+    const promise = waitForActions(mockStore, [action3, action2, action1], { matcher: containing });
+
+    return promise;
 });


### PR DESCRIPTION
BREAKING CHANGE: convert timeout argument to an options object. This commit introduces the matcher concept, which allows to supply a function via options implementing custom comparison of actions. The predicate function, which could be passed until now in the actions argument to perform comparisons, is now no longer supported.

Resolves #6 