### PR TITLE
Remove store subscription and clear timeout when promise settles

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,10 @@ module.exports = (store, expectedActions, options) => {
         const unsubscribe = store.subscribe(() => {
             const promise = matchPromise(store.getActions());
 
-            promise && resolve(promise);
+            if (promise) {
+                teardown();
+                resolve(promise);
+            }
         });
 
         cancel = () => {

--- a/test/util/index.js
+++ b/test/util/index.js
@@ -1,0 +1,4 @@
+'use strict';
+
+exports.assertError = require('./assertError');
+exports.spyOnUnsubscribe = require('./spyOnUnsubscribe');

--- a/test/util/spyOnUnsubscribe.js
+++ b/test/util/spyOnUnsubscribe.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const wrap = require('lodash/wrap');
+
+function spyOnUnsubscribe(mockStore) {
+    let unsubscribeSpy;
+
+    mockStore.subscribe = wrap(mockStore.subscribe, (subscribe, callback) => {
+        const unsubscribe = subscribe(callback);
+
+        unsubscribeSpy = jest.fn(() => unsubscribe());
+
+        return unsubscribeSpy;
+    });
+
+    return () => unsubscribeSpy;
+}
+
+module.exports = spyOnUnsubscribe;


### PR DESCRIPTION
This commit adds several tests to ensure cleanup is performed, i.e., assert that `teardown()` is invoked.
Also added a test to make sure the promise resolves when no actions are expected. 😄 
